### PR TITLE
Fix Android SDK manager installation

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -10,4 +10,10 @@ RUN mkdir -p "$ANDROID_HOME" && \
     unzip -d "$ANDROID_HOME/cmdline-tools/" /tmp/android-cmdline-tools.zip && \
     rm /tmp/android-cmdline-tools.zip
 
+# Install Android SDK
+SHELL ["/bin/bash", "-c"]
+RUN source /home/gitpod/.bashrc.d/99-java && \
+    yes 2>/dev/null | $ANDROID_HOME/cmdline-tools/tools/bin/sdkmanager "platform-tools" "platforms;android-29"
+
+# Update PATH environment variable
 ENV PATH=/home/linuxbrew/.linuxbrew/bin:$ANDROID_HOME/cmdline-tools/tools/bin:$PATH

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,9 +2,7 @@ image:
   file: .gitpod.Dockerfile
 
 tasks:
-  - init: >
-      yes 2>/dev/null | sdkmanager "platform-tools" "platforms;android-29" &&
-      ./gradlew build
+  - init: ./gradlew build
     command: |
       if [[ -z "$APPETIZE_API_TOKEN" ]]; then
           echo "Appetize API token not set. Run:"


### PR DESCRIPTION
Commands that run in the prebuild of Gitpod should not alter files outside of /workspace because only files in /workspace are saved after the prebuild. Without this commit a workspace that has been prebuilt does not have the Android SDK manager installed.