### PR TITLE
Fix Java language server configuration in Gitpod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,3 @@ build
 
 # Other
 .appetize.json
-.classpath
-.project
-.settings/

--- a/.project
+++ b/.project
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>hello-android</name>
+	<comment></comment>
+	<projects>
+	</projects>
+</projectDescription>

--- a/.settings/org.eclipse.buildship.core.prefs
+++ b/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,2 @@
+connection.project.dir=
+eclipse.preferences.version=1

--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -1,6 +1,6 @@
 {
     "files.exclude": {
-        "**/.classpath": true,
+        "**/.classpath": false,
         "**/.factorypath": true,
         "**/.git": true,
         "**/.gradle": true,
@@ -8,5 +8,8 @@
         "**/.settings": true,
         "**/.theia": true,
         "**/gradle": true
-    }
+    },
+    "java.configuration.updateBuildConfiguration": "disabled",
+    "java.import.gradle.enabled": false,
+    "java.import.gradle.wrapper.enabled": false
 }

--- a/README.md
+++ b/README.md
@@ -38,4 +38,5 @@ in a running Gitpod workspace of this repo and restart your workspace or go to h
 - [Android Developer Guides](https://developer.android.com/guide)
 - [Android Developer Guides: Build your first app](https://developer.android.com/training/basics/firstapp)
 - [Android sdkmanager user guide](https://developer.android.com/studio/command-line/sdkmanager)
+- [Android: Build your app from the command line](https://developer.android.com/studio/build/building-cmdline)
 - [fastlane Docs](https://docs.fastlane.tools/)

--- a/app/.classpath
+++ b/app/.classpath
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11/"/>
+	<classpathentry kind="con" path="org.eclipse.buildship.core.gradleclasspathcontainer"/>
+	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="lib" path="build/intermediates/compile_and_runtime_not_namespaced_r_class_jar/debug/R.jar"/>
+	<classpathentry kind="lib" path="/home/gitpod/android/platforms/android-29/android.jar"/>
+	<classpathentry kind="output" path="bin/default"/>
+</classpath>

--- a/app/.project
+++ b/app/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>app</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/app/.settings/org.eclipse.buildship.core.prefs
+++ b/app/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,2 @@
+connection.project.dir=..
+eclipse.preferences.version=1


### PR DESCRIPTION
According to https://github.com/redhat-developer/vscode-java Android is not supported by the RedHat Java Language Server. We can manage it to work when we set the dependencies in the .classpath file explicitly, check in the .project and .settings/* files and disable gradle support.